### PR TITLE
Rightpanel virtualization

### DIFF
--- a/SatisfactorySaveEditor/View/PropertyTemplateDictionary.xaml
+++ b/SatisfactorySaveEditor/View/PropertyTemplateDictionary.xaml
@@ -19,8 +19,8 @@
                     <RowDefinition Height="*"/>
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
-                <ItemsControl Grid.Row="0" ItemsSource="{Binding Elements}">
-                    <ItemsControl.ItemTemplate>
+                <ListBox VirtualizingPanel.IsVirtualizing="True" VirtualizingPanel.VirtualizationMode="Recycling" Grid.Row="0" ItemsSource="{Binding Elements}" MaxHeight="500">
+                    <ListBox.ItemTemplate>
                         <DataTemplate>
                             <GroupBox ToolTip="{Binding ., Converter={StaticResource SerializablePropertyToTypeStringConverter}}">
                                 <GroupBox.Header>
@@ -57,8 +57,8 @@
                                 <ContentControl Content="{Binding .}"/>
                             </GroupBox>
                         </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
+                    </ListBox.ItemTemplate>
+                </ListBox>
                 <Button Grid.Row="1" Content="Add element" Command="{Binding AddElementCommand}"/>
             </Grid>
         </Expander>

--- a/SatisfactorySaveEditor/View/PropertyTemplateDictionary.xaml
+++ b/SatisfactorySaveEditor/View/PropertyTemplateDictionary.xaml
@@ -19,7 +19,7 @@
                     <RowDefinition Height="*"/>
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
-                <ListBox VirtualizingPanel.IsVirtualizing="True" VirtualizingPanel.VirtualizationMode="Recycling" Grid.Row="0" ItemsSource="{Binding Elements}" MaxHeight="500">
+                <ListBox VirtualizingPanel.IsVirtualizing="True" HorizontalContentAlignment="Stretch" VirtualizingPanel.VirtualizationMode="Recycling" Grid.Row="0" ItemsSource="{Binding Elements}" MaxHeight="500">
                     <ListBox.ItemTemplate>
                         <DataTemplate>
                             <GroupBox ToolTip="{Binding ., Converter={StaticResource SerializablePropertyToTypeStringConverter}}">

--- a/SatisfactorySaveEditor/View/PropertyTemplateDictionary.xaml
+++ b/SatisfactorySaveEditor/View/PropertyTemplateDictionary.xaml
@@ -10,7 +10,7 @@
     <converter:IStructToTypeStringConverter x:Key="IStructToTypeStringConverter"/>
 
     <DataTemplate DataType="{x:Type property:ArrayPropertyViewModel}">
-        <Expander>
+        <Expander IsExpanded="{Binding IsExpanded}">
             <Expander.Header>
                 <TextBlock Text="{Binding Elements.Count, StringFormat='{}{0} elements'}"/>
             </Expander.Header>

--- a/SatisfactorySaveEditor/ViewModel/Property/ArrayPropertyViewModel.cs
+++ b/SatisfactorySaveEditor/ViewModel/Property/ArrayPropertyViewModel.cs
@@ -10,12 +10,20 @@ namespace SatisfactorySaveEditor.ViewModel.Property
     {
         private readonly ArrayProperty model;
 
+        private bool isExpanded;
+
         public RelayCommand AddElementCommand { get; }
         public RelayCommand<SerializedPropertyViewModel> RemoveElementCommand { get; }
 
         public ObservableCollection<SerializedPropertyViewModel> Elements { get; }
 
         public string Type => model.Type;
+
+        public bool IsExpanded
+        {
+            get => isExpanded;
+            set { Set(() => IsExpanded, ref isExpanded, value); }
+        }
 
         public ArrayPropertyViewModel(ArrayProperty arrayProperty) : base(arrayProperty)
         {
@@ -25,6 +33,8 @@ namespace SatisfactorySaveEditor.ViewModel.Property
 
             AddElementCommand = new RelayCommand(AddElement);
             RemoveElementCommand = new RelayCommand<SerializedPropertyViewModel>(RemoveElement);
+
+            IsExpanded = Elements.Count <= 3;
         }
 
         private void AddElement()


### PR DESCRIPTION
Closes #45 

Generally improves performance for objects with large arrays by enabling virtualization
Also autoexpands arrays if they are small enough.