### PR TITLE
Implement new exception handling when loading files

### DIFF
--- a/SatisfactorySaveEditor/ViewModel/MainViewModel.cs
+++ b/SatisfactorySaveEditor/ViewModel/MainViewModel.cs
@@ -334,7 +334,7 @@ namespace SatisfactorySaveEditor.ViewModel
             {
                 //should never be reached, but hopefully any users that encounter an error here will report it 
                 MessageBox.Show("An error occurred while creating a backup. The error message will appear when you press 'Ok'.\nPlease tell Goz3rr, Robb, or virusek20 the contents of the error, or report it on the Github Issues page with your log file and save file attached.");
-                log.Error($"Error encountered during backup process:\n{ex.StackTrace}");
+                log.Error(ex);
                 throw;
             }
             finally
@@ -533,10 +533,10 @@ namespace SatisfactorySaveEditor.ViewModel
             {
                 saveGame = new SatisfactorySave(path);
             }
-            catch (FileNotFoundException ex)
+            catch (FileNotFoundException)
             {
                 MessageBox.Show("That file could no longer be found on the disk.\nIt has been removed from the recent files list.", "File not present", MessageBoxButton.OK, MessageBoxImage.Warning);
-                log.Info($"Removing save file {path} from recent saves list");
+                log.Info($"Removing save file {path} from recent saves list since it wasn't found on disk");
                 if (LastFiles != null && LastFiles.Contains(path))
                 {
                     Properties.Settings.Default.LastSaves.Remove(path);

--- a/SatisfactorySaveEditor/ViewModel/MainViewModel.cs
+++ b/SatisfactorySaveEditor/ViewModel/MainViewModel.cs
@@ -533,25 +533,24 @@ namespace SatisfactorySaveEditor.ViewModel
             {
                 saveGame = new SatisfactorySave(path);
             }
+            catch (FileNotFoundException ex)
+            {
+                MessageBox.Show("That file could no longer be found on the disk.\nIt has been removed from the recent files list.", "File not present", MessageBoxButton.OK, MessageBoxImage.Warning);
+                log.Info($"Removing save file {path} from recent saves list");
+                if (LastFiles != null && LastFiles.Contains(path))
+                {
+                    Properties.Settings.Default.LastSaves.Remove(path);
+                    Application.Current.Dispatcher.Invoke(() =>
+                    {
+                        LastFiles.Remove(path);
+                    });
+                }
+                return;
+            }
             catch (Exception ex)
             {
-                if (ex is FileNotFoundException)
-                {
-                    MessageBox.Show("That file could no longer be found on the disk.\nIt has been removed from the recent files list.", "File not present", MessageBoxButton.OK, MessageBoxImage.Warning);
-                    log.Info($"Removing save file {path} from recent saves list");
-                    if (LastFiles != null && LastFiles.Contains(path))
-                    {
-                        Properties.Settings.Default.LastSaves.Remove(path);
-                        Application.Current.Dispatcher.Invoke(() =>
-                        {
-                            LastFiles.Remove(path);
-                        });
-                    }
-                }
-                else
-                {
-                    MessageBox.Show($"An error occurred while opening the file:\n{ex.Message}\n\nCheck the logs for more details.\n\nIf this issue persists, please report it via \"Help > Report an Issue\", and attach the log file and save file you were trying to open.", "Error opening file", MessageBoxButton.OK, MessageBoxImage.Error);
-                }
+                MessageBox.Show($"An error occurred while opening the file:\n{ex.Message}\n\nCheck the logs for more details.\n\nIf this issue persists, please report it via \"Help > Report an Issue\", and attach the log file and save file you were trying to open.", "Error opening file", MessageBoxButton.OK, MessageBoxImage.Error);
+                log.Error(ex);
                 return;
             }
             

--- a/SatisfactorySaveEditor/ViewModel/MainViewModel.cs
+++ b/SatisfactorySaveEditor/ViewModel/MainViewModel.cs
@@ -115,20 +115,25 @@ namespace SatisfactorySaveEditor.ViewModel
             }
 
             var savedFiles = Properties.Settings.Default.LastSaves?.Cast<string>().ToList();
-            bool modified = false;
-            foreach (string filePath in savedFiles) //silently remove files that no longer exist from the list in Properties
+            
+            if(savedFiles != null)
             {
-                if (!File.Exists(filePath))
+                bool modified = false;
+                foreach (string filePath in savedFiles) //silently remove files that no longer exist from the list in Properties
                 {
-                    modified = true;
-                    log.Info($"Removing save file {filePath} from recent saves list since it wasn't found on disk");
-                    Properties.Settings.Default.LastSaves.Remove(filePath);
+                    if (!File.Exists(filePath))
+                    {
+                        modified = true;
+                        log.Info($"Removing save file {filePath} from recent saves list since it wasn't found on disk");
+                        Properties.Settings.Default.LastSaves.Remove(filePath);
+                    }
                 }
-            }
-            if(modified) //regenerate list since a save was not found when first built
-                savedFiles = Properties.Settings.Default.LastSaves?.Cast<string>().ToList();
-            if (savedFiles == null) LastFiles = new ObservableCollection<string>();
-            else LastFiles = new ObservableCollection<string>(savedFiles);
+                if (modified) //regenerate list since a save was not found when first built
+                    savedFiles = Properties.Settings.Default.LastSaves?.Cast<string>().ToList();
+                LastFiles = new ObservableCollection<string>(savedFiles);
+            } 
+            else //create a new empty collection for the list since there isn't anything there
+                LastFiles = new ObservableCollection<string>();
 
             // TODO: load this dynamically
             CheatMenuItems.Add(new ResearchUnlockCheat());

--- a/SatisfactorySaveEditor/ViewModel/MainViewModel.cs
+++ b/SatisfactorySaveEditor/ViewModel/MainViewModel.cs
@@ -226,6 +226,7 @@ namespace SatisfactorySaveEditor.ViewModel
         /// <param name="cheat">The cheat to run</param>
         private void Cheat(ICheat cheat)
         {
+            log.Info($"Applying cheat {cheat.Name}");
             if (cheat.Apply(rootItem))
                 HasUnsavedChanges = true;
         }
@@ -319,6 +320,8 @@ namespace SatisfactorySaveEditor.ViewModel
             string tempFilePath = saveFileDirectory + tempDirectoryName + Path.GetFileName(saveGame.FileName);
             string backupFileFullPath = saveFileDirectory + @"\" + Path.GetFileNameWithoutExtension(saveGame.FileName) + "_" + DateTimeOffset.Now.ToUnixTimeMilliseconds() + ".SSEbkup.zip";
 
+            log.Info($"Creating a {(manual ? "manual " : "")}backup for {saveGame.FileName}");
+
             try
             {
                 //Satisfactory save files compress exceedingly well, so compress all backups so that they take up less space.
@@ -327,10 +330,11 @@ namespace SatisfactorySaveEditor.ViewModel
                 File.Copy(saveGame.FileName, tempFilePath, true); 
                 ZipFile.CreateFromDirectory(pathToZipFrom, backupFileFullPath);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
                 //should never be reached, but hopefully any users that encounter an error here will report it 
-                MessageBox.Show("An error occurred while creating a backup. The error message will appear when you press 'Ok'.\nPlease tell Goz3rr, Robb, or virusek20 the contents of the error.");
+                MessageBox.Show("An error occurred while creating a backup. The error message will appear when you press 'Ok'.\nPlease tell Goz3rr, Robb, or virusek20 the contents of the error, or report it on the Github Issues page with your log file and save file attached.");
+                log.Error($"Error encountered during backup process:\n{ex.StackTrace}");
                 throw;
             }
             finally


### PR DESCRIPTION
I made put this as a separate branch because I'm pretty sure _any_ errors caught while loading a save will be processed by the code I added.

Closes #103.
Logs extra info when perfoming some other save editor operations as well.