### PR TITLE
Write max chunk size in chunk header

### DIFF
--- a/SatisfactorySaveParser/SatisfactorySave.cs
+++ b/SatisfactorySaveParser/SatisfactorySave.cs
@@ -211,7 +211,7 @@ namespace SatisfactorySaveParser
                                 writer.Write(new ChunkInfo()
                                 {
                                     CompressedSize = ChunkInfo.Magic,
-                                    UncompressedSize = remaining
+                                    UncompressedSize = ChunkInfo.ChunkSize
                                 });
 
                                 writer.Write(new ChunkInfo()


### PR DESCRIPTION
The size in the chunk header should be the maximum chunk size, not the size of the current chunk.

I noticed this while analysing the differences when just opening and saving a savegame without any modification.
Seems the only other difference is the different binary encoding of the zlib stream, but I saw there is already a switch to directly using zlib in the newer_parser branch.