### PR TITLE
Add RotateFoundationCheat for world grid user

### DIFF
--- a/SatisfactorySaveEditor/Cheats/RotateFoundationsCheat.cs
+++ b/SatisfactorySaveEditor/Cheats/RotateFoundationsCheat.cs
@@ -1,0 +1,121 @@
+﻿using SatisfactorySaveEditor.Model;
+using SatisfactorySaveParser;
+using SatisfactorySaveParser.Structures;
+using System;
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Forms;
+using MessageBox = System.Windows.MessageBox;
+
+namespace SatisfactorySaveEditor.Cheats
+{
+    class RotateFoundationsCheat : ICheat
+    {
+        public string Name => "Rotate foundations 90, 180, 270 degrees to 0 degrees";
+
+        public bool Apply(SaveObjectModel rootItem, SatisfactorySave saveGame)
+        {
+            return RotateFoundations(rootItem);
+        }
+
+        private enum EnumPositionCorrectionSetting
+        {
+            Nothing,
+            Round
+        }
+
+        private bool RotateFoundations(SaveObjectModel rootItem)
+        {
+            List<SaveObjectModel> foundationsList = rootItem.FindChild("Foundation", true).DescendantSelfViewModel;
+            if (foundationsList == null)
+            {
+                MessageBox.Show("This save does not appear to have any foundations.", "Cannot find any Foundations", MessageBoxButton.OK, MessageBoxImage.Error);
+                return false;
+            }
+
+
+            float rotationZ = 0;
+            float rotationW = 1;
+            double angle = 0;
+            double range = 0.001;
+            int counter = 0;
+
+            EnumPositionCorrectionSetting positionCorrectionSetting;
+            DialogResult dr = (DialogResult)MessageBox.Show("Correct the foundation position (X, Y, Z) to integer?", "Rotate foundations", MessageBoxButton.YesNoCancel, MessageBoxImage.Question);
+            if (dr == DialogResult.Yes) positionCorrectionSetting = EnumPositionCorrectionSetting.Round;
+            else if (dr == DialogResult.No) positionCorrectionSetting = EnumPositionCorrectionSetting.Nothing;
+            else
+            {
+                MessageBox.Show("The process has been canceled.");
+                return false;
+            }
+
+            foundationsList.ForEach(target =>
+            {
+                Vector4 targetRotation = ((SaveEntityModel)target).Rotation;
+                double targetAngle = QuaternionToEuler(targetRotation);
+                // Console.WriteLine(targetRotation+"_" +targetAngle);
+                if ((targetAngle > angle - range && targetAngle < angle + range) ||
+                (targetAngle > angle + 90 - range && targetAngle < angle + 90 + range) ||
+                (targetAngle > angle - 90 - range && targetAngle < angle - 90 + range) ||
+                (targetAngle > angle + 180 - range) ||
+                (targetAngle < angle - 180 + range))
+                {
+                    // Console.WriteLine("rotate");
+                    bool isRotate = false;
+                    if (targetAngle != 0)
+                    {
+                        targetRotation.Z = (float)rotationZ;
+                        targetRotation.W = (float)rotationW;
+                        ((SaveEntityModel)target).Rotation = targetRotation;
+                        isRotate = true;
+                    }
+
+                    bool isCorrect = false;
+                    if (positionCorrectionSetting == EnumPositionCorrectionSetting.Round)
+                    {
+                        Vector3 targetPosition = ((SaveEntityModel)target).Position;
+                        if (targetPosition.X != (int)targetPosition.X &&
+                        targetPosition.Y != (int)targetPosition.Y &&
+                        targetPosition.Z != (int)targetPosition.Z)
+                        {
+                            targetPosition.X = (float)Math.Round(targetPosition.X);
+                            targetPosition.Y = (float)Math.Round(targetPosition.Y);
+                            targetPosition.Z = (float)Math.Round(targetPosition.Z);
+                            ((SaveEntityModel)target).Position = targetPosition;
+                            isCorrect = true;
+                        }
+                    }
+
+                    if (isRotate || isCorrect) counter++;
+                }
+            });
+
+            if (counter == 0)
+            {
+                MessageBox.Show("No changed foundation.");
+                return false;
+            }
+
+            MessageBox.Show($"Successfully aligned {counter} foundations to world grid.");
+            return true;
+        }
+
+        public double QuaternionToEuler(Vector4 rotation)
+        {
+            return Math.Atan2(rotation.Z, rotation.W) * 180 / Math.PI * 2;
+        }
+
+        public Vector4 EulerToQuaternion(double e)
+        {
+            var rotation = new Vector4
+            {
+                X = 0,
+                Y = 0,
+                Z = (float)Math.Round(Math.Sin(e * Math.PI / 180 / 2), 7),
+                W = (float)Math.Round(Math.Cos(e * Math.PI / 180 / 2), 7)
+            };
+            return rotation;
+        }
+    }
+}

--- a/SatisfactorySaveEditor/SatisfactorySaveEditor.csproj
+++ b/SatisfactorySaveEditor/SatisfactorySaveEditor.csproj
@@ -83,6 +83,7 @@
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.Transactions" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\MvvmLightLibs.5.4.1.1\lib\net45\System.Windows.Interactivity.dll</HintPath>
     </Reference>
@@ -109,6 +110,7 @@
     <Compile Include="Cheats\CrateSummonCheat.cs" />
     <Compile Include="Cheats\DeduplicateSchematicsCheat.cs" />
     <Compile Include="Cheats\EverythingBoxCheat.cs" />
+    <Compile Include="Cheats\RotateFoundationsCheat.cs" />
     <Compile Include="Cheats\UndoDeleteEnemiesCheat.cs" />
     <Compile Include="Cheats\ICheat.cs" />
     <Compile Include="Cheats\DeleteEnemiesCheat.cs" />

--- a/SatisfactorySaveEditor/ViewModel/MainViewModel.cs
+++ b/SatisfactorySaveEditor/ViewModel/MainViewModel.cs
@@ -156,6 +156,7 @@ namespace SatisfactorySaveEditor.ViewModel
             CheatMenuItems.Add(new RemoveSlugsCheat());
             CheatMenuItems.Add(new RestoreSlugsCheat());
             CheatMenuItems.Add(new DeduplicateSchematicsCheat());
+            CheatMenuItems.Add(new RotateFoundationsCheat());
 
             TreeSelectCommand = new RelayCommand<SaveObjectModel>(SelectNode);
             JumpCommand = new RelayCommand<string>(Jump, CanJump);


### PR DESCRIPTION
## Summary of changes

* Add RotateFoundationCheat

## Why I'm making this change

* Align the pattern of the base,
* Eliminate positional errors caused by different angles.

## What I did

* List all the foundations,
 change all 90°, 180°, and 270° including 0.001° errors to 0°,
 round the positions to an integer if necessary.

## How to

* Select the "Rotate foundations 90, 180, 270 degrees to 0 degrees" cheat.
* Press yes if you need to round the position of the foundation.

## Challenges

* Is the margin of error appropriate?
* Is the formula for converting from quaternions to Euler angles correct?
