### PR TITLE
Upgrade to .net 5.0; "CanJump" cache added. 

### DIFF
--- a/SatisfactorySaveEditor/App.config
+++ b/SatisfactorySaveEditor/App.config
@@ -34,11 +34,15 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="CommonServiceLocator" publicKeyToken="489b6accfaf20ef0" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.5.0" newVersion="2.0.5.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.6.0" newVersion="2.0.6.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="AsyncAwaitBestPractices" publicKeyToken="532360cfd341384d" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.4.0" newVersion="6.0.4.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/SatisfactorySaveEditor/NLog.xsd
+++ b/SatisfactorySaveEditor/NLog.xsd
@@ -1101,6 +1101,7 @@
       <xs:element name="precision" minOccurs="0" maxOccurs="1" type="xs:byte" />
       <xs:element name="scale" minOccurs="0" maxOccurs="1" type="xs:byte" />
       <xs:element name="parameterType" minOccurs="0" maxOccurs="1" type="xs:string" />
+      <xs:element name="allowDbNull" minOccurs="0" maxOccurs="1" type="xs:boolean" />
       <xs:element name="format" minOccurs="0" maxOccurs="1" type="xs:string" />
       <xs:element name="culture" minOccurs="0" maxOccurs="1" type="xs:string" />
     </xs:choice>
@@ -1137,6 +1138,11 @@
     <xs:attribute name="parameterType" type="xs:string">
       <xs:annotation>
         <xs:documentation>Type of the parameter.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="allowDbNull" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>Whether empty value should translate into DbNull. Requires database column to allow NULL values.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="format" type="xs:string">
@@ -2757,6 +2763,7 @@
           <xs:element name="proxyAddress" minOccurs="0" maxOccurs="1" type="xs:string" />
           <xs:element name="encoding" minOccurs="0" maxOccurs="1" type="xs:string" />
           <xs:element name="url" minOccurs="0" maxOccurs="1" type="xs:anyURI" />
+          <xs:element name="userAgent" minOccurs="0" maxOccurs="1" type="Layout" />
           <xs:element name="escapeDataNLogLegacy" minOccurs="0" maxOccurs="1" type="xs:boolean" />
           <xs:element name="escapeDataRfc3986" minOccurs="0" maxOccurs="1" type="xs:boolean" />
           <xs:element name="preAuthenticate" minOccurs="0" maxOccurs="1" type="xs:boolean" />
@@ -2808,6 +2815,11 @@
         <xs:attribute name="url" type="xs:anyURI">
           <xs:annotation>
             <xs:documentation>Web service URL.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="userAgent" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Value of the User-agent HTTP header.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="escapeDataNLogLegacy" type="xs:boolean">
@@ -2978,6 +2990,7 @@
           <xs:element name="renderEmptyObject" minOccurs="0" maxOccurs="1" type="xs:boolean" />
           <xs:element name="suppressSpaces" minOccurs="0" maxOccurs="1" type="xs:boolean" />
           <xs:element name="attribute" minOccurs="0" maxOccurs="unbounded" type="NLog.Layouts.JsonAttribute" />
+          <xs:element name="excludeEmptyProperties" minOccurs="0" maxOccurs="1" type="xs:boolean" />
           <xs:element name="excludeProperties" minOccurs="0" maxOccurs="1" type="xs:string" />
           <xs:element name="includeAllProperties" minOccurs="0" maxOccurs="1" type="xs:boolean" />
           <xs:element name="includeGdc" minOccurs="0" maxOccurs="1" type="xs:boolean" />
@@ -2998,6 +3011,11 @@
         <xs:attribute name="suppressSpaces" type="xs:boolean">
           <xs:annotation>
             <xs:documentation>Option to suppress the extra spaces in the output json</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="excludeEmptyProperties" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Option to exclude null/empty properties from the log event (as JSON)</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="excludeProperties" type="xs:string">

--- a/SatisfactorySaveEditor/SatisfactorySaveEditor.csproj
+++ b/SatisfactorySaveEditor/SatisfactorySaveEditor.csproj
@@ -41,14 +41,14 @@
     <ApplicationIcon>satisfactorysaveeditorlogo_powershard.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AsyncAwaitBestPractices, Version=1.0.0.0, Culture=neutral, PublicKeyToken=532360cfd341384d, processorArchitecture=MSIL">
-      <HintPath>..\packages\AsyncAwaitBestPractices.4.2.0\lib\netstandard1.0\AsyncAwaitBestPractices.dll</HintPath>
+    <Reference Include="AsyncAwaitBestPractices, Version=6.0.4.0, Culture=neutral, PublicKeyToken=532360cfd341384d, processorArchitecture=MSIL">
+      <HintPath>..\packages\AsyncAwaitBestPractices.6.0.4\lib\netstandard2.0\AsyncAwaitBestPractices.dll</HintPath>
     </Reference>
-    <Reference Include="AsyncAwaitBestPractices.MVVM, Version=1.0.0.0, Culture=neutral, PublicKeyToken=fd3d463fd20deb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\AsyncAwaitBestPractices.MVVM.4.2.0\lib\netstandard1.0\AsyncAwaitBestPractices.MVVM.dll</HintPath>
+    <Reference Include="AsyncAwaitBestPractices.MVVM, Version=6.0.4.0, Culture=neutral, PublicKeyToken=fd3d463fd20deb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\AsyncAwaitBestPractices.MVVM.6.0.4\lib\netstandard2.0\AsyncAwaitBestPractices.MVVM.dll</HintPath>
     </Reference>
-    <Reference Include="CommonServiceLocator, Version=2.0.5.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
-      <HintPath>..\packages\CommonServiceLocator.2.0.5\lib\net47\CommonServiceLocator.dll</HintPath>
+    <Reference Include="CommonServiceLocator, Version=2.0.6.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
+      <HintPath>..\packages\CommonServiceLocator.2.0.6\lib\net47\CommonServiceLocator.dll</HintPath>
     </Reference>
     <Reference Include="GalaSoft.MvvmLight, Version=5.4.1.0, Culture=neutral, PublicKeyToken=e7570ab207bcb616, processorArchitecture=MSIL">
       <HintPath>..\packages\MvvmLightLibs.5.4.1.1\lib\net45\GalaSoft.MvvmLight.dll</HintPath>
@@ -59,14 +59,17 @@
     <Reference Include="GalaSoft.MvvmLight.Platform, Version=5.4.1.0, Culture=neutral, PublicKeyToken=5f873c45e98af8a1, processorArchitecture=MSIL">
       <HintPath>..\packages\MvvmLightLibs.5.4.1.1\lib\net45\GalaSoft.MvvmLight.Platform.dll</HintPath>
     </Reference>
-    <Reference Include="GongSolutions.WPF.DragDrop, Version=2.0.0.0, Culture=neutral, PublicKeyToken=91f1945125b7a587, processorArchitecture=MSIL">
-      <HintPath>..\packages\gong-wpf-dragdrop.2.2.0\lib\net47\GongSolutions.WPF.DragDrop.dll</HintPath>
+    <Reference Include="GongSolutions.WPF.DragDrop, Version=3.0.0.0, Culture=neutral, PublicKeyToken=91f1945125b7a587, processorArchitecture=MSIL">
+      <HintPath>..\packages\gong-wpf-dragdrop.3.1.1\lib\net47\GongSolutions.WPF.DragDrop.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Microsoft.Xaml.Behaviors, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.39\lib\net45\Microsoft.Xaml.Behaviors.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.7.2\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.7.13\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -74,8 +77,8 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.7.1\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />

--- a/SatisfactorySaveEditor/View/PropertyTemplateDictionary.xaml
+++ b/SatisfactorySaveEditor/View/PropertyTemplateDictionary.xaml
@@ -5,7 +5,10 @@
                     xmlns:structs="clr-namespace:SatisfactorySaveParser.PropertyTypes.Structs;assembly=SatisfactorySaveParser"
                     xmlns:control="clr-namespace:SatisfactorySaveEditor.View.Control"
                     xmlns:struct="clr-namespace:SatisfactorySaveEditor.ViewModel.Struct"
-                    xmlns:converter="clr-namespace:SatisfactorySaveEditor.Converter">
+                    xmlns:converter="clr-namespace:SatisfactorySaveEditor.Converter"
+                    xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
+                    xmlns:ei="http://schemas.microsoft.com/expression/2010/interactions"
+                    xmlns:b="http://schemas.microsoft.com/xaml/behaviors">
     <converter:SerializablePropertyToTypeStringConverter x:Key="SerializablePropertyToTypeStringConverter"/>
     <converter:IStructToTypeStringConverter x:Key="IStructToTypeStringConverter"/>
 
@@ -130,8 +133,12 @@
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="50"/>
                     </Grid.ColumnDefinitions>
-                    <TextBox Grid.Column="0" DockPanel.Dock="Left" x:Name="TargetBox" Margin="4" VerticalContentAlignment="Center" Text="{Binding Str2, UpdateSourceTrigger=PropertyChanged}"/>
-                    <Button Grid.Column="1" Command="{Binding RelativeSource={RelativeSource AncestorType={x:Type view:MainWindow}}, Path=DataContext.JumpCommand}" CommandParameter="{Binding Str2}" DockPanel.Dock="Right"  Height="20" VerticalContentAlignment="Center" Content="Jump"/>
+                    <TextBox Grid.Column="0" DockPanel.Dock="Left" x:Name="TargetBox" Margin="4" VerticalContentAlignment="Center" Text="{Binding Str2, UpdateSourceTrigger=LostFocus}" >
+
+                    </TextBox>
+
+                    <Button Grid.Column="1" Command="{Binding RelativeSource={RelativeSource AncestorType={x:Type view:MainWindow}}, Path=DataContext.JumpCommand}" CommandParameter="{Binding Str2}" DockPanel.Dock="Right"  Height="20" VerticalContentAlignment="Center" Content="Jump">
+                    </Button>
                 </Grid>
             </DockPanel>
         </StackPanel>
@@ -150,8 +157,10 @@
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="50"/>
                     </Grid.ColumnDefinitions>
-                    <TextBox Grid.Column="0" DockPanel.Dock="Left" x:Name="TargetBox" Margin="4" VerticalContentAlignment="Center" Text="{Binding Str2, UpdateSourceTrigger=PropertyChanged}"/>
-                    <Button Grid.Column="1" Command="{Binding RelativeSource={RelativeSource AncestorType={x:Type view:MainWindow}}, Path=DataContext.JumpCommand}" CommandParameter="{Binding Str2}" DockPanel.Dock="Right"  Height="20" VerticalContentAlignment="Center" Content="Jump"/>
+                    <TextBox Grid.Column="0" DockPanel.Dock="Left" x:Name="TargetBox" Margin="4" VerticalContentAlignment="Center" Text="{Binding Str2, UpdateSourceTrigger=LostFocus}"/>
+                    <Button Grid.Column="1" Command="{Binding RelativeSource={RelativeSource AncestorType={x:Type view:MainWindow}}, Path=DataContext.JumpCommand}" CommandParameter="{Binding Str2}"
+                             DockPanel.Dock="Right"  Height="20" VerticalContentAlignment="Center" Content="Jump">
+                    </Button>
                 </Grid>
             </DockPanel>
         </StackPanel>

--- a/SatisfactorySaveEditor/ViewModel/MainViewModel.cs
+++ b/SatisfactorySaveEditor/ViewModel/MainViewModel.cs
@@ -380,6 +380,9 @@ namespace SatisfactorySaveEditor.ViewModel
         /// <returns>True if rootItem contains the EntitiyName, false otherwise.</returns>
         private bool CanJump(string target)
         {
+            if (target == null)
+                return false;
+
             return rootItem.FindChild(target, false) != null;
         }
 
@@ -706,6 +709,11 @@ namespace SatisfactorySaveEditor.ViewModel
             SearchText = null;
         }
 
+        public void DragEnter(IDropInfo dropInfo)
+        {
+            // Do nothing
+        }
+
         public void DragOver(IDropInfo dropInfo)
         {
             if (!(dropInfo.Data is DataObject data)) return;
@@ -715,6 +723,11 @@ namespace SatisfactorySaveEditor.ViewModel
 
             dropInfo.DropTargetAdorner = DropTargetAdorners.Insert;
             dropInfo.Effects = DragDropEffects.Copy;
+        }
+
+        public void DragLeave(IDropInfo dropInfo)
+        {
+            // Do nothing
         }
 
         /// <summary>

--- a/SatisfactorySaveEditor/packages.config
+++ b/SatisfactorySaveEditor/packages.config
@@ -1,15 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AsyncAwaitBestPractices" version="4.2.0" targetFramework="net472" />
-  <package id="AsyncAwaitBestPractices.MVVM" version="4.2.0" targetFramework="net472" />
-  <package id="CommonServiceLocator" version="2.0.5" targetFramework="net472" />
-  <package id="gong-wpf-dragdrop" version="2.2.0" targetFramework="net472" />
+  <package id="AsyncAwaitBestPractices" version="6.0.4" targetFramework="net472" />
+  <package id="AsyncAwaitBestPractices.MVVM" version="6.0.4" targetFramework="net472" />
+  <package id="CommonServiceLocator" version="2.0.6" targetFramework="net472" />
+  <package id="gong-wpf-dragdrop" version="3.1.1" targetFramework="net472" />
+  <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.39" targetFramework="net472" />
   <package id="MvvmLight" version="5.4.1.1" targetFramework="net462" />
   <package id="MvvmLightLibs" version="5.4.1.1" targetFramework="net462" />
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" />
-  <package id="NLog" version="4.7.2" targetFramework="net472" />
-  <package id="NLog.Config" version="4.7.2" targetFramework="net472" />
-  <package id="NLog.Schema" version="4.7.2" targetFramework="net472" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net472" />
+  <package id="NLog" version="4.7.13" targetFramework="net472" />
+  <package id="NLog.Config" version="4.7.13" targetFramework="net472" />
+  <package id="NLog.Schema" version="4.7.13" targetFramework="net472" />
+  <package id="System.Reflection.Emit.Lightweight" version="4.7.0" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net472" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
 </packages>

--- a/SatisfactorySaveParser.Tests/SatisfactorySaveParser.Tests.csproj
+++ b/SatisfactorySaveParser.Tests/SatisfactorySaveParser.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
Unfortunately, I have to upgrade this thing to .Net 5.0 otherwise my VS2022 wouldn't open it. 
Added a "CanJump" cache class to cache the queries every 10 minutes. This function causes a lot of lag when editing recipes, as it can't find the target but it tries too many times when editing the available recipes.