### PR TITLE
Add Update 6 read support

### DIFF
--- a/SatisfactorySaveParser/PropertyTypes/SetProperty.cs
+++ b/SatisfactorySaveParser/PropertyTypes/SetProperty.cs
@@ -135,6 +135,22 @@ namespace SatisfactorySaveParser.PropertyTypes
                         }
                     }
                     break;
+                case StructProperty.TypeName:
+                    {
+                        if (propertyName != "mRemovalLocations")
+                        {
+                            throw new NotImplementedException("Parsing a set of StructProperty other than mRemovalLocations is not yet supported");
+                        }
+                        var locationsCount = reader.ReadInt32();
+                        for (var i = 0; i < locationsCount; i++)
+                        {
+                            var location = new Structs.Vector(reader);
+                            var element = new StructProperty("location", i);
+                            element.Data = location;
+                            result.Elements.Add(element);
+                        }
+                    }
+                    break;
                 default:
                     throw new NotImplementedException($"Parsing a set of {result.Type} is not yet supported.");
             }

--- a/SatisfactorySaveParser/SatisfactorySave.cs
+++ b/SatisfactorySaveParser/SatisfactorySave.cs
@@ -1,4 +1,5 @@
 ﻿using NLog;
+using SatisfactorySaveParser.Exceptions;
 using SatisfactorySaveParser.Save;
 using SatisfactorySaveParser.Structures;
 using SatisfactorySaveParser.ZLib;
@@ -176,6 +177,16 @@ namespace SatisfactorySaveParser
         public void Save(string file)
         {
             log.Info($"Writing save file: {file}");
+
+            // FIXME update 6 savefile can be loaded, but not saved yet
+            if (Header.SaveVersion > FSaveCustomVersion.TrainBlueprintClassAdded)
+            {
+                throw new UnknownBuildVersionException(Header.SaveVersion);
+            }
+            if (Header.HeaderVersion > SaveHeaderVersion.UE426EngineUpdate)
+            {
+                throw new UnknownSaveVersionException(Header.HeaderVersion);
+            }
 
             FileName = Environment.ExpandEnvironmentVariables(file);
             using (var stream = new FileStream(FileName, FileMode.OpenOrCreate, FileAccess.Write))

--- a/SatisfactorySaveParser/Save/FSaveCustomVersion.cs
+++ b/SatisfactorySaveParser/Save/FSaveCustomVersion.cs
@@ -90,6 +90,12 @@
         // 2021-09-21 Migrate FGTrain from native only to a blueprint class BP_Train.
         TrainBlueprintClassAdded,
 
+        // 2021-12-03: Added sublevel streaming support
+        AddedSublevelStreaming,
+
+        // 2022-07-28: Added Coloring support to concrete pillars, in post load we check if the swatch if the default one, if so we swap it with concrete.
+        AddedColoringSupportToConcretePillars,
+
         // -----<new versions can be added above this line>-------------------------------------------------
         VersionPlusOne,
         LatestVersion = VersionPlusOne - 1

--- a/SatisfactorySaveParser/Save/FSaveHeader.cs
+++ b/SatisfactorySaveParser/Save/FSaveHeader.cs
@@ -68,6 +68,11 @@ namespace SatisfactorySaveParser.Save
         /// </summary>
         public bool IsModdedSave { get; set; }
 
+        /// <summary>
+        ///     a unique identifier for this save, for analytics purposes
+        /// </summary>
+        public string SaveIdentifier { get; set; }
+
         public void Serialize(BinaryWriter writer)
         {
             writer.Write((int)HeaderVersion);
@@ -135,6 +140,12 @@ namespace SatisfactorySaveParser.Save
                 header.ModMetadata = reader.ReadLengthPrefixedString();
                 header.IsModdedSave = reader.ReadInt32() > 0;
                 log.Debug($"ModMetadata={header.ModMetadata}, IsModdedSave={header.IsModdedSave}");
+            }
+
+            if (header.HeaderVersion >= SaveHeaderVersion.AddedSaveIdentifier)
+            {
+                header.SaveIdentifier = reader.ReadLengthPrefixedString();
+                log.Debug($"SaveIdentifier={header.SaveIdentifier}");
             }
 
             return header;

--- a/SatisfactorySaveParser/Save/SaveHeaderVersion.cs
+++ b/SatisfactorySaveParser/Save/SaveHeaderVersion.cs
@@ -32,6 +32,9 @@
         // @2021-04-15 UE4.26 Engine Upgrade. FEditorObjectVersion Changes occurred
         UE426EngineUpdate,
 
+        // @2022-03-22 Added GUID to identify saves, it is for analytics purposes.
+        AddedSaveIdentifier,
+
         // -----<new versions can be added above this line>-----
         VersionPlusOne,
         LatestVersion = VersionPlusOne - 1 // Last version to use


### PR DESCRIPTION
Added the new headers and parsing for the sublevel saving introduced in Update 6. This does not include saving such a file, I added two FIXMEs for the original maintainer to implement. This also means that older savefiles are not supported, because my changes are not backwards compatible.

Currently there are many issues open that want update 6 support, so maybe this is a start.