### PR TITLE
Add U6 and U7 read write support

### DIFF
--- a/SatisfactorySaveEditor/Cheats/EverythingBoxCheat.cs
+++ b/SatisfactorySaveEditor/Cheats/EverythingBoxCheat.cs
@@ -1,16 +1,13 @@
-﻿using SatisfactorySaveEditor.Model;
-using SatisfactorySaveEditor.View;
-using SatisfactorySaveEditor.ViewModel;
-using SatisfactorySaveEditor.ViewModel.Property;
-using SatisfactorySaveParser;
-using SatisfactorySaveParser.Data;
-using SatisfactorySaveParser.PropertyTypes;
-using SatisfactorySaveParser.PropertyTypes.Structs;
-using SatisfactorySaveParser.Structures;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Windows;
+using SatisfactorySaveEditor.Model;
+using SatisfactorySaveEditor.View;
+using SatisfactorySaveEditor.ViewModel;
+using SatisfactorySaveParser;
+using SatisfactorySaveParser.Data;
+using SatisfactorySaveParser.PropertyTypes;
 
 namespace SatisfactorySaveEditor.Cheats
 {
@@ -101,7 +98,7 @@ namespace SatisfactorySaveEditor.Cheats
             }
 
             //Use Mass Dismantle Cheat's crate creation function to package the items into a crate entity
-            MassDismantleCheat.CreateCrateEntityFromInventory(rootItem, inventory, saveGame.Header.BuildVersion);
+            MassDismantleCheat.CreateCrateEntityFromInventory(saveGame.Header.MapName, rootItem, inventory, saveGame.Header.BuildVersion);
 
             //MessageBox.Show("Player name " + playerEntityModel.Title);
             MessageBox.Show($"Crate created.\nNote that normally unstackable items will visually display as being stacked to 1. Use Ctrl+Click to transfer items out of the crate without deleting part of the stack.\n\nSkipped the following items marked as radioactive:\n\n{skipped}", $"Processed {resourceStrings.Count} resource paths");

--- a/SatisfactorySaveEditor/Cheats/KillPlayersCheat.cs
+++ b/SatisfactorySaveEditor/Cheats/KillPlayersCheat.cs
@@ -37,13 +37,13 @@ namespace SatisfactorySaveEditor.Cheats
                 if (!InventoryEmpty(inventoryComponent))
                 {
                     currentStorageID = GetNextStorageID(currentStorageID, rootItem);
-                    SaveComponent newInventory = new SaveComponent(inventoryComponent.TypePath, inventoryComponent.RootObject, $"Persistent_Level:PersistentLevel.BP_Crate_C_{currentStorageID}.inventory")
+                    SaveComponent newInventory = new SaveComponent(saveGame.Header.MapName, inventoryComponent.TypePath, inventoryComponent.RootObject, $"Persistent_Level:PersistentLevel.BP_Crate_C_{currentStorageID}.inventory")
                     {
                         ParentEntityName = $"Persistent_Level:PersistentLevel.BP_Crate_C_{currentStorageID}",
                         DataFields = inventoryComponent.DataFields
                     };
                     rootItem.FindChild("FactoryGame.FGInventoryComponent", false).Items.Add(new SaveComponentModel(newInventory));
-                    SaveEntity newSaveObject = new SaveEntity("/Game/FactoryGame/-Shared/Crate/BP_Crate.BP_Crate_C", "Persistent_Level", $"Persistent_Level:PersistentLevel.BP_Crate_C_{currentStorageID}")
+                    SaveEntity newSaveObject = new SaveEntity(saveGame.Header.MapName, "/Game/FactoryGame/-Shared/Crate/BP_Crate.BP_Crate_C", "Persistent_Level", $"Persistent_Level:PersistentLevel.BP_Crate_C_{currentStorageID}")
                     {
                         NeedTransform = true,
                         Rotation = ((SaveEntity)player.Model).Rotation,

--- a/SatisfactorySaveEditor/Cheats/MassDismantleCheat.cs
+++ b/SatisfactorySaveEditor/Cheats/MassDismantleCheat.cs
@@ -217,16 +217,16 @@ namespace SatisfactorySaveEditor.Cheats
             MessageBoxResult result = MessageBox.Show($"Dismantled {countFactory} factory buildings, {countBuilding} foundations and {countCrate} crates. Drop the items (including items in storages) in a single crate?", "Dismantled", MessageBoxButton.YesNo, MessageBoxImage.Question);
             if (result == MessageBoxResult.Yes)
             {
-                CreateCrateEntityFromInventory(rootItem, inventory, saveGame.Header.BuildVersion);
+                CreateCrateEntityFromInventory(saveGame.Header.MapName, rootItem, inventory, saveGame.Header.BuildVersion);
             }
             return true;
         }
 
-        public static SaveEntityModel CreateCrateEntityFromInventory(SaveObjectModel rootItem, ArrayProperty inventory, int buildVersion)
+        public static SaveEntityModel CreateCrateEntityFromInventory(string levelname, SaveObjectModel rootItem, ArrayProperty inventory, int buildVersion)
         {
             inventory = ArrangeInventory(inventory, buildVersion);
             int currentStorageID = GetNextStorageID(0, rootItem);
-            SaveComponent newInventory = new SaveComponent("/Script/FactoryGame.FGInventoryComponent", "Persistent_Level", $"Persistent_Level:PersistentLevel.BP_Crate_C_{currentStorageID}.inventory")
+            SaveComponent newInventory = new SaveComponent(levelname, "/Script/FactoryGame.FGInventoryComponent", "Persistent_Level", $"Persistent_Level:PersistentLevel.BP_Crate_C_{currentStorageID}.inventory")
             {
                 ParentEntityName = $"Persistent_Level:PersistentLevel.BP_Crate_C_{currentStorageID}",
                 DataFields = new SerializedFields()
@@ -250,7 +250,7 @@ namespace SatisfactorySaveEditor.Cheats
             };
             rootItem.FindChild("FactoryGame.FGInventoryComponent", false).Items.Add(new SaveComponentModel(newInventory));
             SaveEntity player = (SaveEntity)rootItem.FindChild("Char_Player.Char_Player_C", false).DescendantSelf[0];
-            SaveEntity newSaveObject = new SaveEntity("/Game/FactoryGame/-Shared/Crate/BP_Crate.BP_Crate_C", "Persistent_Level", $"Persistent_Level:PersistentLevel.BP_Crate_C_{currentStorageID}")
+            SaveEntity newSaveObject = new SaveEntity(levelname, "/Game/FactoryGame/-Shared/Crate/BP_Crate.BP_Crate_C", "Persistent_Level", $"Persistent_Level:PersistentLevel.BP_Crate_C_{currentStorageID}")
             {
                 NeedTransform = true,
                 Rotation = player.Rotation,

--- a/SatisfactorySaveEditor/Cheats/RemoveSlugsCheat.cs
+++ b/SatisfactorySaveEditor/Cheats/RemoveSlugsCheat.cs
@@ -23,14 +23,18 @@ namespace SatisfactorySaveEditor.Cheats
                 "/Game/FactoryGame/Resource/Environment/Crystal/BP_Crystal_mk3.BP_Crystal_mk3_C"
             };
 
-            var slugs = saveGame.Entries.Where(x => slugTypes.Contains(x.TypePath));
-
-            saveGame.CollectedObjects.RemoveAll(x => x.PathName.Contains("PersistentLevel.BP_Crystal"));
-            saveGame.CollectedObjects.AddRange(slugs.Select(s => new ObjectReference
+            foreach (var level in saveGame.Levels)
             {
-                LevelName = s.RootObject,
-                PathName = s.InstanceName
-            }));
+
+                var slugs = level.Entries.Where(x => slugTypes.Contains(x.TypePath));
+
+                level.CollectedObjects.RemoveAll(x => x.PathName.Contains("PersistentLevel.BP_Crystal"));
+                level.CollectedObjects.AddRange(slugs.Select(s => new ObjectReference
+                {
+                    LevelName = s.RootObject,
+                    PathName = s.InstanceName
+                }));
+            }
 
             return true;
         }

--- a/SatisfactorySaveEditor/Cheats/RemoveSlugsCheat.cs
+++ b/SatisfactorySaveEditor/Cheats/RemoveSlugsCheat.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
+﻿using System.Linq;
+using System.Windows;
 using SatisfactorySaveEditor.Model;
-
 using SatisfactorySaveParser;
 using SatisfactorySaveParser.Structures;
 
@@ -17,25 +12,35 @@ namespace SatisfactorySaveEditor.Cheats
 
         public bool Apply(SaveObjectModel rootItem, SatisfactorySave saveGame)
         {
+            MessageBox.Show("Can only remove already discovered slugs on the map. Continue?", "Remove slugs?", MessageBoxButton.YesNo);
+            
             var slugTypes = new[] {
                 "/Game/FactoryGame/Resource/Environment/Crystal/BP_Crystal.BP_Crystal_C",
                 "/Game/FactoryGame/Resource/Environment/Crystal/BP_Crystal_mk2.BP_Crystal_mk2_C",
                 "/Game/FactoryGame/Resource/Environment/Crystal/BP_Crystal_mk3.BP_Crystal_mk3_C"
             };
+            
+            var slugsMk1 = rootItem.FindChild("BP_Crystal.BP_Crystal_C", false);
+            var slugsMk2 = rootItem.FindChild("BP_Crystal_mk2.BP_Crystal_mk2_C", false);
+            var slugsMk3 = rootItem.FindChild("BP_Crystal_mk3.BP_Crystal_mk3_C", false);
 
-            foreach (var level in saveGame.Levels)
+            foreach (SaveLevel level in saveGame.Levels)
             {
+                var slugsForLevel = level.Entries.Where(x => slugTypes.Contains(x.TypePath));
+                var readyToCollectSlugs = slugsForLevel.Where(slug => !slug.RootObject.Equals("Persistent_Exploration_2"));
 
-                var slugs = level.Entries.Where(x => slugTypes.Contains(x.TypePath));
-
-                level.CollectedObjects.RemoveAll(x => x.PathName.Contains("PersistentLevel.BP_Crystal"));
-                level.CollectedObjects.AddRange(slugs.Select(s => new ObjectReference
+                level.CollectedObjects.AddRange(readyToCollectSlugs.Select(s => new ObjectReference
                 {
                     LevelName = s.RootObject,
                     PathName = s.InstanceName
                 }));
             }
+            
+            slugsMk1.Items.Clear();
+            slugsMk2.Items.Clear();
+            slugsMk3.Items.Clear();
 
+            MessageBox.Show("Removed discovered slugs on the map.", "Removed slugs.", MessageBoxButton.OK);
             return true;
         }
     }

--- a/SatisfactorySaveEditor/Cheats/RestoreSlugsCheat.cs
+++ b/SatisfactorySaveEditor/Cheats/RestoreSlugsCheat.cs
@@ -11,7 +11,11 @@ namespace SatisfactorySaveEditor.Cheats
 
         public bool Apply(SaveObjectModel rootItem, SatisfactorySave saveGame)
         {
-            saveGame.CollectedObjects.RemoveAll(x => x.PathName.Contains("PersistentLevel.BP_Crystal"));
+            foreach (var level in saveGame.Levels)
+            {
+                level.CollectedObjects.RemoveAll(x => x.PathName.Contains("PersistentLevel.BP_Crystal"));
+            }
+            
             return true;
         }
     }

--- a/SatisfactorySaveEditor/Cheats/RestoreSlugsCheat.cs
+++ b/SatisfactorySaveEditor/Cheats/RestoreSlugsCheat.cs
@@ -1,6 +1,6 @@
 ﻿
+using System.Windows;
 using SatisfactorySaveEditor.Model;
-
 using SatisfactorySaveParser;
 
 namespace SatisfactorySaveEditor.Cheats
@@ -16,6 +16,7 @@ namespace SatisfactorySaveEditor.Cheats
                 level.CollectedObjects.RemoveAll(x => x.PathName.Contains("PersistentLevel.BP_Crystal"));
             }
             
+            MessageBox.Show("Restored all slugs on the map.", "Restored Slugs.", MessageBoxButton.OK);
             return true;
         }
     }

--- a/SatisfactorySaveEditor/Cheats/SpawnDoggoCheat.cs
+++ b/SatisfactorySaveEditor/Cheats/SpawnDoggoCheat.cs
@@ -1,17 +1,9 @@
-﻿using SatisfactorySaveEditor.Model;
+﻿using System;
+using System.Windows;
+using SatisfactorySaveEditor.Model;
 using SatisfactorySaveEditor.View;
 using SatisfactorySaveEditor.ViewModel;
 using SatisfactorySaveParser;
-using SatisfactorySaveParser.PropertyTypes;
-using SatisfactorySaveParser.PropertyTypes.Structs;
-using SatisfactorySaveParser.Structures;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
 
 namespace SatisfactorySaveEditor.Cheats
 {

--- a/SatisfactorySaveEditor/Cheats/UndoDeleteEnemiesCheat.cs
+++ b/SatisfactorySaveEditor/Cheats/UndoDeleteEnemiesCheat.cs
@@ -58,11 +58,10 @@ namespace SatisfactorySaveEditor.Cheats
                 {
                     foreach (StructPropertyViewModel elem in arrayProperty.Elements)
                     {
-                        if (probablyEdited)
-                            ((Vector)((StructProperty)((DynamicStructDataViewModel)elem.StructData).Fields[0].Model).Data).Data.Z -= offset; // Move the spawn point under the map
-
                         // Set WasKilled to true so they don't respawn after deleting them
-                        ((BoolPropertyViewModel)((DynamicStructDataViewModel)elem.StructData).Fields[2]).Value = false;
+                        ((BoolPropertyViewModel)((DynamicStructDataViewModel)elem.StructData).Fields[1]).Value = false;
+                        // Set NumTimesKilled to at least 1 i guess. Better to increment.
+                        ((IntPropertyViewModel)((DynamicStructDataViewModel)elem.StructData).Fields[2]).Value -= 1;
                         // Set KilledOnDayNumber to a huge number (some far away animals respawn if the number is too small)
                         ((IntPropertyViewModel)((DynamicStructDataViewModel)elem.StructData).Fields[3]).Value = (int)0;
                     }

--- a/SatisfactorySaveEditor/Model/SaveObjectModel.cs
+++ b/SatisfactorySaveEditor/Model/SaveObjectModel.cs
@@ -16,6 +16,7 @@ namespace SatisfactorySaveEditor.Model
 {
     public class SaveObjectModel : ViewModelBase
     {
+        private string levelName;
         private string title;
         private string rootObject;
         private string type;
@@ -63,6 +64,12 @@ namespace SatisfactorySaveEditor.Model
             }
         }
 
+        public string LevelName
+        {
+            get => levelName;
+            set { Set(() => LevelName, ref levelName, value); }
+        }
+        
         public string Title
         {
             get => title;
@@ -98,6 +105,7 @@ namespace SatisfactorySaveEditor.Model
         public SaveObjectModel(SaveObject model)
         {
             Model = model;
+            LevelName = model.LevelName;
             Title = model.InstanceName;
             RootObject = model.RootObject;
             Type = model.TypePath.Split('/').Last();

--- a/SatisfactorySaveEditor/View/MainWindow.xaml
+++ b/SatisfactorySaveEditor/View/MainWindow.xaml
@@ -298,27 +298,30 @@
                                     <RowDefinition/>
                                     <RowDefinition/>
                                     <RowDefinition/>
+                                    <RowDefinition/>
                                 </Grid.RowDefinitions>
 
-                                <Label Margin="0,2,0,2" Grid.Column="0" Grid.Row="0" Content="Entity name:"/>
-                                <Label Margin="0,2,0,2" Grid.Column="0" Grid.Row="1" Content="Root:"/>
-                                <Label Margin="0,2,0,2" Grid.Column="0" Grid.Row="2" Content="NeedTransform:"/>
-                                <Label Margin="0,2,0,2" Grid.Column="0" Grid.Row="3" Content="WasPlacedInLevel:"/>
-                                <Label Margin="0,2,0,2" Grid.Column="0" Grid.Row="4" Content="Position:"/>
-                                <Label Margin="0,2,0,2" Grid.Column="0" Grid.Row="5" Content="Rotation:"/>
-                                <Label Margin="0,2,0,2" Grid.Column="0" Grid.Row="6" Content="Scale:"/>
-                                <Label Margin="0,2,0,2" Grid.Column="0" Grid.Row="7" Content="ParentObjectName:"/>
-                                <Label Margin="0,2,0,2" Grid.Column="0" Grid.Row="8" Content="ParentObjectRoot:"/>
+                                <Label Margin="0,2,0,2" Grid.Column="0" Grid.Row="0" Content="Level name:"/>
+                                <Label Margin="0,2,0,2" Grid.Column="0" Grid.Row="1" Content="Entity name:"/>
+                                <Label Margin="0,2,0,2" Grid.Column="0" Grid.Row="2" Content="Root:"/>
+                                <Label Margin="0,2,0,2" Grid.Column="0" Grid.Row="3" Content="NeedTransform:"/>
+                                <Label Margin="0,2,0,2" Grid.Column="0" Grid.Row="4" Content="WasPlacedInLevel:"/>
+                                <Label Margin="0,2,0,2" Grid.Column="0" Grid.Row="5" Content="Position:"/>
+                                <Label Margin="0,2,0,2" Grid.Column="0" Grid.Row="6" Content="Rotation:"/>
+                                <Label Margin="0,2,0,2" Grid.Column="0" Grid.Row="7" Content="Scale:"/>
+                                <Label Margin="0,2,0,2" Grid.Column="0" Grid.Row="8" Content="ParentObjectName:"/>
+                                <Label Margin="0,2,0,2" Grid.Column="0" Grid.Row="9" Content="ParentObjectRoot:"/>
 
-                                <TextBox Margin="20,2,0,2" VerticalContentAlignment="Center" HorizontalAlignment="Left" Width="400" Grid.Column="1" Grid.Row="0" Text="{Binding Title, UpdateSourceTrigger=PropertyChanged, Delay=250}"/>
-                                <TextBox Margin="20,2,0,2" VerticalContentAlignment="Center" HorizontalAlignment="Left" Width="400" Grid.Column="1" Grid.Row="1" Text="{Binding RootObject}" IsEnabled="False"/>
-                                <CheckBox Margin="20,2,0,2" VerticalContentAlignment="Center" HorizontalAlignment="Left" Width="80" Grid.Column="1" Grid.Row="2" IsChecked="{Binding NeedTransform}" IsEnabled="False"/>
-                                <CheckBox Margin="20,2,0,2" VerticalContentAlignment="Center" HorizontalAlignment="Left" Width="80" Grid.Column="1" Grid.Row="3" IsChecked="{Binding WasPlacedInLevel}" IsEnabled="False"/>
-                                <control:Vector3Control Margin="0,2,0,2" Grid.Column="1" Grid.Row="4" Vector="{Binding Position}"/>
-                                <control:Vector4Control Margin="0,2,0,2" Grid.Column="1" Grid.Row="5" Vector="{Binding Rotation}"/>
-                                <control:Vector3Control Margin="0,2,0,2" Grid.Column="1" Grid.Row="6" Vector="{Binding Scale}"/>
-                                <TextBox Margin="20,2,0,2" VerticalContentAlignment="Center" HorizontalAlignment="Left" Width="400" Grid.Column="1" Grid.Row="7" Text="{Binding ParentObjectName}" IsEnabled="False"/>
-                                <TextBox Margin="20,2,0,2" VerticalContentAlignment="Center" HorizontalAlignment="Left" Width="400" Grid.Column="1" Grid.Row="8" Text="{Binding ParentObjectRoot}" IsEnabled="False"/>
+                                <TextBox Margin="20,2,0,2" VerticalContentAlignment="Center" HorizontalAlignment="Left" Width="400" Grid.Column="1" Grid.Row="0" Text="{Binding LevelName}" IsEnabled="False"/>
+                                <TextBox Margin="20,2,0,2" VerticalContentAlignment="Center" HorizontalAlignment="Left" Width="400" Grid.Column="1" Grid.Row="1" Text="{Binding Title, UpdateSourceTrigger=PropertyChanged, Delay=250}"/>
+                                <TextBox Margin="20,2,0,2" VerticalContentAlignment="Center" HorizontalAlignment="Left" Width="400" Grid.Column="1" Grid.Row="2" Text="{Binding RootObject}" IsEnabled="False"/>
+                                <CheckBox Margin="20,2,0,2" VerticalContentAlignment="Center" HorizontalAlignment="Left" Width="80" Grid.Column="1" Grid.Row="3" IsChecked="{Binding NeedTransform}" IsEnabled="False"/>
+                                <CheckBox Margin="20,2,0,2" VerticalContentAlignment="Center" HorizontalAlignment="Left" Width="80" Grid.Column="1" Grid.Row="4" IsChecked="{Binding WasPlacedInLevel}" IsEnabled="False"/>
+                                <control:Vector3Control Margin="0,2,0,2" Grid.Column="1" Grid.Row="5" Vector="{Binding Position}"/>
+                                <control:Vector4Control Margin="0,2,0,2" Grid.Column="1" Grid.Row="6" Vector="{Binding Rotation}"/>
+                                <control:Vector3Control Margin="0,2,0,2" Grid.Column="1" Grid.Row="7" Vector="{Binding Scale}"/>
+                                <TextBox Margin="20,2,0,2" VerticalContentAlignment="Center" HorizontalAlignment="Left" Width="400" Grid.Column="1" Grid.Row="8" Text="{Binding ParentObjectName}" IsEnabled="False"/>
+                                <TextBox Margin="20,2,0,2" VerticalContentAlignment="Center" HorizontalAlignment="Left" Width="400" Grid.Column="1" Grid.Row="9" Text="{Binding ParentObjectRoot}" IsEnabled="False"/>
                             </Grid>
                             <control:PropertiesControl Properties="{Binding Fields}" AddPropertyCommand="{Binding AddPropertyCommand}" RemovePropertyCommand="{Binding RemovePropertyCommand}"/>
                         </DockPanel>
@@ -335,15 +338,18 @@
                                     <RowDefinition/>
                                     <RowDefinition/>
                                     <RowDefinition/>
+                                    <RowDefinition/>
                                 </Grid.RowDefinitions>
 
-                                <Label Margin="0,2,0,2" Grid.Column="0" Grid.Row="0" Content="Component name:"/>
-                                <Label Margin="0,2,0,2" Grid.Column="0" Grid.Row="1" Content="Root:"/>
-                                <Label Margin="0,2,0,2" Grid.Column="0" Grid.Row="2" Content="ParentEntityName:"/>
+                                <Label Margin="0,2,0,2" Grid.Column="0" Grid.Row="0" Content="Level name:"/>
+                                <Label Margin="0,2,0,2" Grid.Column="0" Grid.Row="1" Content="Component name:"/>
+                                <Label Margin="0,2,0,2" Grid.Column="0" Grid.Row="2" Content="Root:"/>
+                                <Label Margin="0,2,0,2" Grid.Column="0" Grid.Row="3" Content="ParentEntityName:"/>
 
-                                <TextBox Margin="20,2,0,2" VerticalContentAlignment="Center" HorizontalAlignment="Left" Width="400" Grid.Column="1" Grid.Row="0" Text="{Binding Title, UpdateSourceTrigger=PropertyChanged, Delay=250}"/>
-                                <TextBox Margin="20,2,0,2" VerticalContentAlignment="Center" HorizontalAlignment="Left" Width="400" Grid.Column="1" Grid.Row="1" Text="{Binding RootObject}" IsEnabled="False"/>
-                                <TextBox Margin="20,2,0,2" VerticalContentAlignment="Center" HorizontalAlignment="Left" Width="400" Grid.Column="1" Grid.Row="2" Text="{Binding ParentEntityName}" IsEnabled="False"/>
+                                <TextBox Margin="20,2,0,2" VerticalContentAlignment="Center" HorizontalAlignment="Left" Width="400" Grid.Column="1" Grid.Row="0" Text="{Binding LevelName}" IsEnabled="False"/>
+                                <TextBox Margin="20,2,0,2" VerticalContentAlignment="Center" HorizontalAlignment="Left" Width="400" Grid.Column="1" Grid.Row="1" Text="{Binding Title, UpdateSourceTrigger=PropertyChanged, Delay=250}"/>
+                                <TextBox Margin="20,2,0,2" VerticalContentAlignment="Center" HorizontalAlignment="Left" Width="400" Grid.Column="1" Grid.Row="2" Text="{Binding RootObject}" IsEnabled="False"/>
+                                <TextBox Margin="20,2,0,2" VerticalContentAlignment="Center" HorizontalAlignment="Left" Width="400" Grid.Column="1" Grid.Row="3" Text="{Binding ParentEntityName}" IsEnabled="False"/>
                             </Grid>
                             <control:PropertiesControl Properties="{Binding Fields}" AddPropertyCommand="{Binding AddPropertyCommand}" RemovePropertyCommand="{Binding RemovePropertyCommand}"/>
                         </DockPanel>

--- a/SatisfactorySaveParser/Metadata/ConveyorBeltLiftMetaData.cs
+++ b/SatisfactorySaveParser/Metadata/ConveyorBeltLiftMetaData.cs
@@ -1,0 +1,22 @@
+﻿using System.IO;
+
+namespace SatisfactorySaveParser.Metadata
+{
+    public class ConveyorBeltLiftMetaData : SaveObjectMetaData
+    {
+        public ConveyorItemMetaData[] Items;
+        
+        public override void ParseData(BinaryReader reader)
+        {
+            base.ParseData(reader);
+            
+            int numItems = reader.ReadInt32();
+            Items = new ConveyorItemMetaData[numItems];
+            for (int i = 0; i < numItems; i++)
+            {
+                Items[i] = new ConveyorItemMetaData();
+                Items[i].ParseData(reader);
+            }
+        }
+    }
+}

--- a/SatisfactorySaveParser/Metadata/ConveyorItemMetaData.cs
+++ b/SatisfactorySaveParser/Metadata/ConveyorItemMetaData.cs
@@ -1,0 +1,22 @@
+﻿using System.IO;
+
+namespace SatisfactorySaveParser.Metadata
+{
+    public class ConveyorItemMetaData : SaveObjectMetaData
+    {
+
+        public string ItemPathName;
+        public float Position;
+        
+        public override void ParseData(BinaryReader reader)
+        {
+            base.ParseData(reader);
+            
+            reader.ReadInt32();
+            ItemPathName = reader.ReadLengthPrefixedString();
+            reader.ReadLengthPrefixedString();
+            reader.ReadLengthPrefixedString();
+            Position = reader.ReadSingle();
+        }
+    }
+}

--- a/SatisfactorySaveParser/Metadata/SaveObjectMetaData.cs
+++ b/SatisfactorySaveParser/Metadata/SaveObjectMetaData.cs
@@ -1,0 +1,12 @@
+﻿using System.IO;
+
+namespace SatisfactorySaveParser.Metadata
+{
+    public class SaveObjectMetaData
+    {
+        public virtual void ParseData(BinaryReader reader)
+        {
+            
+        }
+    }
+}

--- a/SatisfactorySaveParser/PropertyTypes/ArrayProperty.cs
+++ b/SatisfactorySaveParser/PropertyTypes/ArrayProperty.cs
@@ -85,6 +85,15 @@ namespace SatisfactorySaveParser.PropertyTypes
                             }
                         }
                         break;
+                    case Int64Property.TypeName:
+                        {
+                            msWriter.Write(Elements.Count);
+                            foreach (var prop in Elements.Cast<Int64Property>())
+                            {
+                                msWriter.Write(prop.Value);
+                            }
+                        }
+                        break;
                     case ByteProperty.TypeName:
                         {
                             msWriter.Write(Elements.Count);
@@ -193,6 +202,17 @@ namespace SatisfactorySaveParser.PropertyTypes
                         {
                             var value = reader.ReadInt32();
                             result.Elements.Add(new IntProperty($"Element {i}") { Value = value });
+                        }
+                    }
+                    break;
+                
+                case Int64Property.TypeName:
+                    {
+                        var count = reader.ReadInt32();
+                        for (var i = 0; i < count; i++)
+                        {
+                            var value = reader.ReadInt64();
+                            result.Elements.Add(new Int64Property($"Element {i}") { Value = value });
                         }
                     }
                     break;

--- a/SatisfactorySaveParser/SatisfactorySave.cs
+++ b/SatisfactorySaveParser/SatisfactorySave.cs
@@ -6,8 +6,10 @@ using SatisfactorySaveParser.ZLib;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.Eventing;
 using System.IO;
 using System.Linq;
+using SatisfactorySaveParser.Exceptions;
 
 namespace SatisfactorySaveParser
 {
@@ -37,7 +39,13 @@ namespace SatisfactorySaveParser
         ///     List of object references of all collected objects in the world (Nut/berry bushes, slugs, etc)
         /// </summary>
         public List<ObjectReference> CollectedObjects { get; set; } = new List<ObjectReference>();
+        
+        /// <summary>
+        ///     List of levels in the save
+        /// </summary>
+        public List<SaveLevel> Levels { get; set; } = new List<SaveLevel>();
 
+        
         /// <summary>
         ///     Open a savefile from disk
         /// </summary>
@@ -60,7 +68,7 @@ namespace SatisfactorySaveParser
 
                 if (Header.SaveVersion < FSaveCustomVersion.SaveFileIsCompressed)
                 {
-                    LoadData(reader);
+                    LoadDataU5AndBelow(reader);
                 }
                 else
                 {
@@ -104,14 +112,21 @@ namespace SatisfactorySaveParser
                             var dataLength = bufferReader.ReadInt32();
                             Trace.Assert(uncompressedSize == dataLength + 4);
 
-                            LoadData(bufferReader);
+                            if (Header.SaveVersion < FSaveCustomVersion.AddedSublevelStreaming)
+                            {
+                                LoadDataU5AndBelow(bufferReader);
+                            }
+                            else
+                            {
+                                LoadDataU6AndAbove(bufferReader);
+                            }
                         }
                     }
                 }
             }
         }
 
-        private void LoadData(BinaryReader reader)
+        private void LoadDataU5AndBelow(BinaryReader reader)
         {
             // Does not need to be a public property because it's equal to Entries.Count
             var totalSaveObjects = reader.ReadUInt32();
@@ -168,6 +183,103 @@ namespace SatisfactorySaveParser
             Trace.Assert(reader.BaseStream.Position == reader.BaseStream.Length);
         }
 
+        private void LoadDataU6AndAbove(BinaryReader reader)
+        {
+            var sublevelCount = reader.ReadInt32();
+            for (int sublevelIndex = 0;
+                 sublevelIndex <= sublevelCount;
+                 sublevelIndex++) // sublevels and the "persistent level" at the end!
+            {
+                var levelName = (sublevelIndex == sublevelCount)
+                    ? Header.MapName
+                    : reader.ReadLengthPrefixedString(); // use MapName for the persistent level
+                SaveLevel level = new SaveLevel(levelName);
+                Levels.Add(level);
+
+                var levelEntries = LoadLevelEntries(reader, levelName);
+                Entries.AddRange(levelEntries);
+                level.ContainedObjectInstances.AddRange(levelEntries.Select(entry => entry.InstanceName));
+                
+                var levelCollectedObjects = LoadLevelCollectedObjects(reader);
+                CollectedObjects.AddRange(levelCollectedObjects);
+                level.ContainedCollectablesInstances.AddRange(levelCollectedObjects);
+                
+                log.Info($"Reading level [{sublevelIndex+1}/{Levels.Count}] with {Levels[sublevelIndex].ContainedObjectInstances.Count} objects and {Levels[sublevelIndex].ContainedCollectablesInstances.Count} collectables: {Levels[sublevelIndex].Name}.");
+                
+                ParseLevelEntries(levelEntries, reader);
+                LoadLevelCollectedObjects(reader); // skip second collectables
+            }
+        }
+
+
+        private List<SaveObject> LoadLevelEntries(BinaryReader reader, string levelname)
+        {
+            reader.ReadInt32(); // skip "object header and collectables size"
+            var levelEntries = new List<SaveObject>();
+            var totalSaveObjects = reader.ReadInt32();
+
+            for (int i = 0; i < totalSaveObjects; i++)
+            {
+                var type = reader.ReadInt32();
+                switch (type)
+                {
+                    case SaveEntity.TypeID:
+                        var entity = new SaveEntity(reader);
+                        entity.LevelName = levelname;
+                        levelEntries.Add(entity);
+                        break;
+                    case SaveComponent.TypeID:
+                        var component = new SaveComponent(reader);
+                        component.LevelName = levelname;
+                        levelEntries.Add(component);
+                        break;
+                    default:
+                        throw new InvalidOperationException($"Unexpected type {type}");
+                }
+            }
+
+            return levelEntries;
+        }
+        
+        private List<ObjectReference> LoadLevelCollectedObjects(BinaryReader reader)
+        {
+            var levelCollectedObjects = new List<ObjectReference>();
+            var collectedObjectsCount = reader.ReadInt32();
+
+            for (int i = 0; i < collectedObjectsCount; i++)
+            {
+                var collected = new ObjectReference(reader);
+                levelCollectedObjects.Add(collected);
+            }
+            return levelCollectedObjects;
+        }
+
+        private void ParseLevelEntries(List<SaveObject> levelEntries, BinaryReader reader)
+        {
+            reader.ReadInt32(); // skip "objects binary size"
+            var objectCount = reader.ReadInt32();
+            Trace.Assert(levelEntries.Count == objectCount);
+            
+            for (int i = 0; i < objectCount; i++)
+            {
+                var len = reader.ReadInt32();
+                var before = reader.BaseStream.Position;
+
+#if DEBUG
+                //log.Trace($"Reading {len} bytes @ {before} for {levelEntries[i].TypePath}");
+#endif
+
+                levelEntries[i].ParseData(len, reader, Header.BuildVersion);
+                var after = reader.BaseStream.Position;
+
+                if (before + len != after)
+                {
+                    throw new InvalidOperationException($"Expected {len} bytes read but got {after - before}");
+                }
+            }
+        }
+
+        
         public void Save()
         {
             Save(FileName);
@@ -187,7 +299,7 @@ namespace SatisfactorySaveParser
 
                 if (Header.SaveVersion < FSaveCustomVersion.SaveFileIsCompressed)
                 {
-                    SaveData(writer, Header.BuildVersion);
+                    SaveDataU5AndBelow(writer, Header.BuildVersion);
                 }
                 else
                 {
@@ -196,7 +308,14 @@ namespace SatisfactorySaveParser
                     {
                         bufferWriter.Write(0); // Placeholder size
 
-                        SaveData(bufferWriter, Header.BuildVersion);
+                        if (Header.SaveVersion < FSaveCustomVersion.AddedSublevelStreaming)
+                        {
+                            SaveDataU5AndBelow(bufferWriter, Header.BuildVersion);
+                        }
+                        else
+                        {
+                            SaveDataU6AndAbove(bufferWriter, Header.BuildVersion);
+                        }
 
                         buffer.Position = 0;
                         bufferWriter.Write((int)buffer.Length - 4);
@@ -243,29 +362,116 @@ namespace SatisfactorySaveParser
             }
         }
 
-        private void SaveData(BinaryWriter writer, int buildVersion)
+        private void SaveDataU6AndAbove(BinaryWriter writer, int buildVersion)
         {
-            writer.Write(Entries.Count);
+            writer.Write(Levels.Count-1);
 
-            var entities = Entries.Where(e => e is SaveEntity).ToArray();
+            for (int i = 0; i < Levels.Count; i++)
+            {
+                if (!Levels[i].Name.Equals(Header.MapName))
+                {
+                    writer.WriteLengthPrefixedString(Levels[i].Name);
+                }
+
+                log.Info($"Writing level [{i+1}/{Levels.Count}] with {Levels[i].ContainedObjectInstances.Count} objects and {Levels[i].ContainedCollectablesInstances.Count} collectables: {Levels[i].Name}.");
+
+                using (var buffer = new MemoryStream())
+                using (var subLevelWriter = new BinaryWriter(buffer))
+                {
+                    
+                    // write object headers (entities and components)
+                    var levelObjects = Levels[i].ContainedObjectInstances.Select(instanceName =>
+                        Entries.First(entry => entry.InstanceName.Equals(instanceName))).ToList();
+                    var entities = levelObjects.Where(e => e is SaveEntity).Cast<SaveEntity>().ToArray();
+                    var components = levelObjects.Where(e => e is SaveComponent).Cast<SaveComponent>().ToArray();
+                    SaveObjectsHeaderList(subLevelWriter, buildVersion, entities, components);
+                    
+                    // write collected objects list
+                    var levelCollectables = Levels[i].ContainedCollectablesInstances;
+                    SaveCollectablesList(subLevelWriter, buildVersion, levelCollectables);
+
+                    var bufferedContent = buffer.ToArray();
+                    writer.Write(bufferedContent.Length);
+                    writer.Write(bufferedContent);
+                }
+                
+                // write objects content + collectables.
+                using (var buffer = new MemoryStream())
+                using (var subLevelWriter = new BinaryWriter(buffer))
+                {
+                    
+                    // write object content (entities and components)
+                    var levelObjects = Levels[i].ContainedObjectInstances.Select(instanceName =>
+                        Entries.First(entry => entry.InstanceName.Equals(instanceName))).ToList();
+                    var entities = levelObjects.Where(e => e is SaveEntity).Cast<SaveEntity>().ToArray();
+                    var components = levelObjects.Where(e => e is SaveComponent).Cast<SaveComponent>().ToArray();
+                    SaveObjectsContentList(subLevelWriter, buildVersion, entities, components);
+                    
+                    // write collected objects list
+                    var levelCollectables = Levels[i].ContainedCollectablesInstances;
+                    SaveCollectablesList(subLevelWriter, buildVersion, levelCollectables);
+
+                    var bufferedContent = buffer.ToArray();
+                    writer.Write(bufferedContent.Length);
+                    writer.Write(bufferedContent);
+                }
+            }
+        }
+
+        private void SaveDataU5AndBelow(BinaryWriter writer, int buildVersion)
+        {
+            SaveDataU5AndBelow(writer, buildVersion, Entries, CollectedObjects);
+        }
+        
+        private void SaveDataU5AndBelow(BinaryWriter writer, int buildVersion, List<SaveObject> entries, List<ObjectReference> collectedObjects)
+        {
+            SaveObjectsList(writer, buildVersion, entries);
+            SaveCollectablesList(writer, buildVersion, collectedObjects);
+        }
+
+        private void SaveCollectablesList(in BinaryWriter writer, in int buildVersion, in List<ObjectReference> collectedObjects)
+        {
+            writer.Write(collectedObjects.Count);
+            foreach (var collectedObject in collectedObjects)
+            {
+                writer.WriteLengthPrefixedString(collectedObject.LevelName);
+                writer.WriteLengthPrefixedString(collectedObject.PathName);
+            }
+        }
+
+        private void SaveObjectsList(in BinaryWriter writer, in int buildVersion, in List<SaveObject> objects)
+        {
+            var entities = objects.Where(e => e is SaveEntity).Cast<SaveEntity>().ToArray();
+            var components = objects.Where(e => e is SaveComponent).Cast<SaveComponent>().ToArray();
+            SaveObjectsHeaderList(writer, buildVersion, entities, components);
+            SaveObjectsContentList(writer, buildVersion, entities, components);
+        }
+
+        private void SaveObjectsHeaderList(in BinaryWriter writer, in int buildVersion, in SaveEntity[] entities, in SaveComponent[] components)
+        {
+            writer.Write(entities.Length + components.Length);
+            
             for (var i = 0; i < entities.Length; i++)
             {
                 writer.Write(SaveEntity.TypeID);
                 entities[i].SerializeHeader(writer);
             }
 
-            var components = Entries.Where(e => e is SaveComponent).ToArray();
             for (var i = 0; i < components.Length; i++)
             {
                 writer.Write(SaveComponent.TypeID);
                 components[i].SerializeHeader(writer);
             }
-
+        }
+        
+        private void SaveObjectsContentList(in BinaryWriter writer, in int buildVersion, in SaveEntity[] entities, in SaveComponent[] components)
+        {
             writer.Write(entities.Length + components.Length);
 
             using (var ms = new MemoryStream())
             using (var dataWriter = new BinaryWriter(ms))
             {
+                
                 for (var i = 0; i < entities.Length; i++)
                 {
                     entities[i].SerializeData(dataWriter, buildVersion);
@@ -286,13 +492,6 @@ namespace SatisfactorySaveParser
 
                     ms.SetLength(0);
                 }
-            }
-
-            writer.Write(CollectedObjects.Count);
-            foreach (var collectedObject in CollectedObjects)
-            {
-                writer.WriteLengthPrefixedString(collectedObject.LevelName);
-                writer.WriteLengthPrefixedString(collectedObject.PathName);
             }
         }
     }

--- a/SatisfactorySaveParser/SatisfactorySave.cs
+++ b/SatisfactorySaveParser/SatisfactorySave.cs
@@ -286,7 +286,10 @@ namespace SatisfactorySaveParser
             }
 
             long ReadBytesCount = reader.BaseStream.Position - Before;
-            Debug.Assert(ReadBytesCount == binarySize);
+            if (ReadBytesCount != binarySize)
+            {
+                log.Warn("The indicated size does not match the real size! Save is probably corrupt. Attempting to load what's possible.");
+            }
         }
 
         

--- a/SatisfactorySaveParser/SatisfactorySaveParser.csproj
+++ b/SatisfactorySaveParser/SatisfactorySaveParser.csproj
@@ -75,6 +75,9 @@
     <Compile Include="Exceptions\FatalSaveException.cs" />
     <Compile Include="Exceptions\UnknownBuildVersionException.cs" />
     <Compile Include="Exceptions\UnknownSaveVersionException.cs" />
+    <Compile Include="Metadata\ConveyorBeltLiftMetaData.cs" />
+    <Compile Include="Metadata\ConveyorItemMetaData.cs" />
+    <Compile Include="Metadata\SaveObjectMetaData.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PropertyTypes\ArrayProperty.cs" />
     <Compile Include="PropertyTypes\BoolProperty.cs" />

--- a/SatisfactorySaveParser/SatisfactorySaveParser.csproj
+++ b/SatisfactorySaveParser/SatisfactorySaveParser.csproj
@@ -117,6 +117,7 @@
     <Compile Include="SatisfactorySave.cs" />
     <Compile Include="SaveComponent.cs" />
     <Compile Include="SaveEntity.cs" />
+    <Compile Include="SaveLevel.cs" />
     <Compile Include="SaveObject.cs" />
     <Compile Include="Save\ChunkInfo.cs" />
     <Compile Include="Save\EIntroTutorialSteps.cs" />

--- a/SatisfactorySaveParser/Save/FSaveCustomVersion.cs
+++ b/SatisfactorySaveParser/Save/FSaveCustomVersion.cs
@@ -89,7 +89,31 @@
 
         // 2021-09-21 Migrate FGTrain from native only to a blueprint class BP_Train.
         TrainBlueprintClassAdded,
+        
+        // 2021-12-03: Added sublevel streaming support
+        AddedSublevelStreaming,
+        
+        // 2022-08-10: Added additional track progression path to resource sink subsystem
+        AddedResourceSinkTrack,
 
+        // 2022-07-28: Added Coloring support to concrete pillars, in post load we check if the swatch if the default one, if so we swap it with concrete.
+        AddedColoringSupportToConcretePillars,
+
+        // 2022-10-24: Readded since AddedColoringSupportToConcretePillars was merged to main
+        AddedResourceSinkTrack2,
+
+        // 2022-10-18: Added Cached locations for wire locations for use in visualization in blueprint hologram (can't depend on connection components)
+        AddedCachedLocationsForWire,
+
+        // 2022-11-17: Added migration of inventories from the old splitters and mergers to the new ones that have a smaller inventories.
+        ReworkedSplittersAndMergers,
+
+        // 2022-11-23: Added new productivity monitor implementation.
+        ReworkedProductivityMonitor,
+
+        // 2022-11-25: Nativized shopping list and added blueprint support.
+        NativizedShoppingList,
+        
         // -----<new versions can be added above this line>-------------------------------------------------
         VersionPlusOne,
         LatestVersion = VersionPlusOne - 1

--- a/SatisfactorySaveParser/Save/FSaveHeader.cs
+++ b/SatisfactorySaveParser/Save/FSaveHeader.cs
@@ -67,6 +67,11 @@ namespace SatisfactorySaveParser.Save
         ///     Was this save ever saved with mods enabled?
         /// </summary>
         public bool IsModdedSave { get; set; }
+        
+        /// <summary>
+        ///     a unique identifier for this save, for analytics purposes
+        /// </summary>
+        public string SaveIdentifier { get; set; }
 
         public void Serialize(BinaryWriter writer)
         {
@@ -92,6 +97,9 @@ namespace SatisfactorySaveParser.Save
                 writer.WriteLengthPrefixedString(ModMetadata);
                 writer.Write(IsModdedSave ? 1 : 0);
             }
+            
+            if (HeaderVersion >= SaveHeaderVersion.AddedSaveIdentifier)
+                writer.WriteLengthPrefixedString(SaveIdentifier);
         }
 
         public static FSaveHeader Parse(BinaryReader reader)
@@ -135,6 +143,12 @@ namespace SatisfactorySaveParser.Save
                 header.ModMetadata = reader.ReadLengthPrefixedString();
                 header.IsModdedSave = reader.ReadInt32() > 0;
                 log.Debug($"ModMetadata={header.ModMetadata}, IsModdedSave={header.IsModdedSave}");
+            }
+            
+            if (header.HeaderVersion >= SaveHeaderVersion.AddedSaveIdentifier)
+            {
+                header.SaveIdentifier = reader.ReadLengthPrefixedString();
+                log.Debug($"SaveIdentifier={header.SaveIdentifier}");
             }
 
             return header;

--- a/SatisfactorySaveParser/Save/SaveHeaderVersion.cs
+++ b/SatisfactorySaveParser/Save/SaveHeaderVersion.cs
@@ -31,6 +31,9 @@
 
         // @2021-04-15 UE4.26 Engine Upgrade. FEditorObjectVersion Changes occurred
         UE426EngineUpdate,
+        
+        // @2022-01-06 Added GUID to identify saves, it is for analytics purposes.
+        AddedSaveIdentifier,
 
         // -----<new versions can be added above this line>-----
         VersionPlusOne,

--- a/SatisfactorySaveParser/SaveComponent.cs
+++ b/SatisfactorySaveParser/SaveComponent.cs
@@ -15,11 +15,11 @@ namespace SatisfactorySaveParser
         /// </summary>
         public string ParentEntityName { get; set; }
 
-        public SaveComponent(string typePath, string rootObject, string instanceName) : base(typePath, rootObject, instanceName)
+        public SaveComponent(string levelname, string typePath, string rootObject, string instanceName) : base(levelname, typePath, rootObject, instanceName)
         {
         }
 
-        public SaveComponent(BinaryReader reader) : base(reader)
+        public SaveComponent(string levelname, BinaryReader reader) : base(levelname, reader)
         {
             ParentEntityName = reader.ReadLengthPrefixedString();
         }

--- a/SatisfactorySaveParser/SaveEntity.cs
+++ b/SatisfactorySaveParser/SaveEntity.cs
@@ -51,11 +51,11 @@ namespace SatisfactorySaveParser
         /// </summary>
         public List<ObjectReference> Components { get; set; } = new List<ObjectReference>();
 
-        public SaveEntity(string typePath, string rootObject, string instanceName) : base(typePath, rootObject, instanceName)
+        public SaveEntity(string levelname, string typePath, string rootObject, string instanceName) : base(levelname, typePath, rootObject, instanceName)
         {
         }
-
-        public SaveEntity(BinaryReader reader) : base(reader)
+        
+        public SaveEntity(string levelname, BinaryReader reader) : base(levelname, reader)
         {
             NeedTransform = reader.ReadInt32() == 1;
             Rotation = reader.ReadVector4();

--- a/SatisfactorySaveParser/SaveLevel.cs
+++ b/SatisfactorySaveParser/SaveLevel.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using SatisfactorySaveParser.Structures;
+
+namespace SatisfactorySaveParser
+{
+    public class SaveLevel
+    {
+        /// <summary>
+        /// The name of the level
+        /// </summary>
+        public string Name;
+
+        /// <summary>
+        /// a list of object instance names that belong in this level.
+        /// </summary>
+        public List<string> ContainedObjectInstances = new List<string>();
+        
+        
+        /// <summary>
+        /// a list of references to collected objects, that belong in this level
+        /// </summary>
+        public List<ObjectReference> ContainedCollectablesInstances = new List<ObjectReference>();
+        
+        public SaveLevel(string name)
+        {
+            Name = name;
+        }
+    }
+}

--- a/SatisfactorySaveParser/SaveLevel.cs
+++ b/SatisfactorySaveParser/SaveLevel.cs
@@ -15,13 +15,13 @@ namespace SatisfactorySaveParser
         /// <summary>
         /// a list of object instance names that belong in this level.
         /// </summary>
-        public List<string> ContainedObjectInstances = new List<string>();
+        public List<SaveObject> Entries = new List<SaveObject>();
         
         
         /// <summary>
         /// a list of references to collected objects, that belong in this level
         /// </summary>
-        public List<ObjectReference> ContainedCollectablesInstances = new List<ObjectReference>();
+        public List<ObjectReference> CollectedObjects = new List<ObjectReference>();
         
         public SaveLevel(string name)
         {

--- a/SatisfactorySaveParser/SaveObject.cs
+++ b/SatisfactorySaveParser/SaveObject.cs
@@ -1,5 +1,11 @@
-﻿using NLog;
+﻿using System;
+using System.Diagnostics;
+using NLog;
 using System.IO;
+using System.Linq;
+using NLog.Fluent;
+using SatisfactorySaveParser.Metadata;
+using SatisfactorySaveParser.PropertyTypes.Structs;
 
 namespace SatisfactorySaveParser
 {
@@ -31,11 +37,23 @@ namespace SatisfactorySaveParser
         /// </summary>
         public SerializedFields DataFields { get; set; }
 
+        /// <summary>
+        ///     meta data from the trailing bytes
+        /// </summary>
+        public SaveObjectMetaData MetaData { get; set; }
+        
+        
+        /// <summary>
+        /// the level name this object belongs to (introduced in U6)
+        /// </summary>
+        public string LevelName { get; set; }
+
         public SaveObject(string typePath, string rootObject, string instanceName)
         {
             TypePath = typePath;
             RootObject = rootObject;
             InstanceName = instanceName;
+            MetaData = new SaveObjectMetaData();
         }
 
         protected SaveObject(BinaryReader reader)
@@ -60,6 +78,142 @@ namespace SatisfactorySaveParser
         public virtual void ParseData(int length, BinaryReader reader, int buildVersion)
         {
             DataFields = SerializedFields.Parse(length, reader, buildVersion);
+
+            // safely parse trailing data, there are some additional properties for some objects
+            if (DataFields.TrailingData != null && DataFields.TrailingData.Length > 0)
+            {
+
+                var dataCopy = DataFields.TrailingData.ToArray();
+                using (var trailingReader = new BinaryReader(new MemoryStream(dataCopy)))
+                {
+                    ParseTrailingAdditionalData(trailingReader);
+                }
+            }
+        }
+    
+        private void ParseTrailingAdditionalData(BinaryReader reader)
+        {
+            switch (TypePath)
+            {
+                case "/Game/FactoryGame/Buildable/Factory/ConveyorBeltMk1/Build_ConveyorBeltMk1.Build_ConveyorBeltMk1_C":
+                case "/Game/FactoryGame/Buildable/Factory/ConveyorBeltMk2/Build_ConveyorBeltMk2.Build_ConveyorBeltMk2_C":
+                case "/Game/FactoryGame/Buildable/Factory/ConveyorBeltMk3/Build_ConveyorBeltMk3.Build_ConveyorBeltMk3_C":
+                case "/Game/FactoryGame/Buildable/Factory/ConveyorBeltMk4/Build_ConveyorBeltMk4.Build_ConveyorBeltMk4_C":
+                case "/Game/FactoryGame/Buildable/Factory/ConveyorBeltMk5/Build_ConveyorBeltMk5.Build_ConveyorBeltMk5_C":
+                case "/Game/FactoryGame/Buildable/Factory/ConveyorLiftMk1/Build_ConveyorLiftMk1.Build_ConveyorLiftMk1_C":
+                case "/Game/FactoryGame/Buildable/Factory/ConveyorLiftMk2/Build_ConveyorLiftMk2.Build_ConveyorLiftMk2_C":
+                case "/Game/FactoryGame/Buildable/Factory/ConveyorLiftMk3/Build_ConveyorLiftMk3.Build_ConveyorLiftMk3_C":
+                case "/Game/FactoryGame/Buildable/Factory/ConveyorLiftMk4/Build_ConveyorLiftMk4.Build_ConveyorLiftMk4_C":
+                case "/Game/FactoryGame/Buildable/Factory/ConveyorLiftMk5/Build_ConveyorLiftMk5.Build_ConveyorLiftMk5_C":
+                    MetaData = new ConveyorBeltLiftMetaData();
+                    MetaData.ParseData(reader);
+                    break;
+                case "/Game/FactoryGame/Buildable/Factory/DroneStation/BP_DroneTransport.BP_DroneTransport_C":
+                    var droneStuff = reader.ReadInt32();
+                    break;
+                case "/Game/FactoryGame/-Shared/Blueprint/BP_GameMode.BP_GameMode_C":
+                    var mode = reader.ReadInt32();
+                    break;
+                case "/Game/FactoryGame/-Shared/Blueprint/BP_GameState.BP_GameState_C":
+                    // player state children
+                    var numPlayerStates = reader.ReadInt32();
+                    for (int i = 0; i < numPlayerStates; i++)
+                    {
+                        var lvlname = reader.ReadLengthPrefixedString();
+                        var pthname = reader.ReadLengthPrefixedString();
+                    }
+
+                    break;
+                case "/Game/FactoryGame/Character/Player/BP_PlayerState.BP_PlayerState_C":
+                    var playerType = reader.ReadByte();
+                    switch (playerType)
+                    {
+                        case 248:
+                            var eos = reader.ReadLengthPrefixedString();
+                            var eosId = reader.ReadLengthPrefixedString();
+                            break;
+                        case 25:
+                            break;
+                        case 8:
+                            var platformId = reader.ReadLengthPrefixedString();
+                            break;
+                        case 3:
+                            break;
+                    }
+
+                    break;
+                case "/Game/FactoryGame/-Shared/Blueprint/BP_CircuitSubsystem.BP_CircuitSubsystem_C":
+                    var numCircuitSubsystems = reader.ReadInt32();
+                    for (int i = 0; i < numCircuitSubsystems; i++)
+                    {
+                        var circuitId = reader.ReadInt32();
+                        var lvlname = reader.ReadLengthPrefixedString();
+                        var pthname = reader.ReadLengthPrefixedString();
+                    }
+
+                    break;
+                case "/Game/FactoryGame/Buildable/Factory/PowerLine/Build_PowerLine.Build_PowerLine_C":
+                case "/Game/FactoryGame/Events/Christmas/Buildings/PowerLineLights/Build_XmassLightsLine.Build_XmassLightsLine_C":
+
+                    var lvlnameSource = reader.ReadLengthPrefixedString();
+                    var instanceNameSource = reader.ReadLengthPrefixedString();
+                    var lvlNameTarget = reader.ReadLengthPrefixedString();
+                    var instanceNameTarget = reader.ReadLengthPrefixedString();
+
+                    // can have 6 floats
+                    if (reader.BaseStream.Position < reader.BaseStream.Length)
+                    {
+                        reader.ReadSingle();
+                        reader.ReadSingle();
+                        reader.ReadSingle();
+                        reader.ReadSingle();
+                        reader.ReadSingle();
+                        reader.ReadSingle();
+                    }
+
+                    break;
+                case "/Game/FactoryGame/Buildable/Vehicle/Train/Locomotive/BP_Locomotive.BP_Locomotive_C":
+                case "/Game/FactoryGame/Buildable/Vehicle/Train/Wagon/BP_FreightWagon.BP_FreightWagon_C":
+                    var padding = reader.ReadInt32();
+                    while (reader.BaseStream.Position < reader.BaseStream.Length)
+                    {
+                        var wagonLevelName = reader.ReadLengthPrefixedString();
+                        var wagonInstanceName = reader.ReadLengthPrefixedString();
+                    }
+
+                    break;
+                case "/Game/FactoryGame/Buildable/Vehicle/Tractor/BP_Tractor.BP_Tractor_C":
+                case "/Game/FactoryGame/Buildable/Vehicle/Truck/BP_Truck.BP_Truck_C":
+                case "/Game/FactoryGame/Buildable/Vehicle/Explorer/BP_Explorer.BP_Explorer_C":
+                case "/Game/FactoryGame/Buildable/Vehicle/Cyberwagon/Testa_BP_WB.Testa_BP_WB_C":
+                case "/Game/FactoryGame/Buildable/Vehicle/Golfcart/BP_Golfcart.BP_Golfcart_C":
+                case "/Game/FactoryGame/Buildable/Vehicle/Golfcart/BP_GolfcartGold.BP_GolfcartGold_C":
+                    var hasAdditionalData = reader.ReadInt32();
+
+                    // conditionally can have more
+                    if (reader.BaseStream.Position < reader.BaseStream.Length)
+                    {
+                        var parentName = reader.ReadLengthPrefixedString();
+                        var position = reader.ReadVector3();
+                        var rotation = reader.ReadVector3();
+
+                        // Not sure what it is. Always seems to be 29 Bytes.
+                        reader.ReadInt32();
+                        reader.ReadInt32();
+                        reader.ReadInt32();
+                        reader.ReadInt32();
+                        reader.ReadInt32();
+                        reader.ReadInt32();
+                        reader.ReadInt32();
+                        reader.ReadByte();
+                    }
+
+                    break;
+                default:
+                    // there are types that we did not cover yet. skip parsing until we update this behavior.
+                    reader.BaseStream.Position = reader.BaseStream.Length;
+                    break;
+            }
         }
 
         public override string ToString()

--- a/SatisfactorySaveParser/SaveObject.cs
+++ b/SatisfactorySaveParser/SaveObject.cs
@@ -48,16 +48,18 @@ namespace SatisfactorySaveParser
         /// </summary>
         public string LevelName { get; set; }
 
-        public SaveObject(string typePath, string rootObject, string instanceName)
+        public SaveObject(string levelname, string typePath, string rootObject, string instanceName)
         {
+            LevelName = levelname;
             TypePath = typePath;
             RootObject = rootObject;
             InstanceName = instanceName;
             MetaData = new SaveObjectMetaData();
         }
 
-        protected SaveObject(BinaryReader reader)
+        protected SaveObject(string levelname, BinaryReader reader)
         {
+            LevelName = levelname;
             TypePath = reader.ReadLengthPrefixedString();
             RootObject = reader.ReadLengthPrefixedString();
             InstanceName = reader.ReadLengthPrefixedString();


### PR DESCRIPTION
This PR aims at adding readability/saveability to U6 and U7 saves.
Even though the repo is as good as dead, it might be a starting point for future work or forks. Since i was tinkering with it in my free time anyway.

It should be backwards compatible with older saves, but very well may be able to be optimized.
Since i don't fully understand the code structure of the parser. Just enough to make this change happen, hopefully without much issue.

A lot of credit goes to Thomas for his fork for adding u6 readability https://github.com/Goz3rr/SatisfactorySaveEditor/pull/262. A large part of my changes were possible because of his work.

Edit: Please note that this does not update cheats or anything else rather than just being able to open and write saves.
Some cheats are definitely broken in this PR.